### PR TITLE
Updated the Sharp dependency to v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^2.4.1",
     "minimatch": "^1.0.0",
     "rename": "^0.2.3",
-    "sharp": "^0.8.0",
+    "sharp": "^0.9.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading to v0.9.0 of Sharp seems to have solved the Segmentation fault: 11 I was getting on OS X