### PR TITLE
Expose more underlying sharp methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,14 @@ Configuration unit is an object:
 * progressive: *Boolean* - progressive (interlace) scan for JPEG and PNG output, default `false`
 * withMetadata: *Boolean* - include image metadata, default `false`
 * compressionLevel: *Number* - zlib compression level for PNG, default `6`
-* rename: *String* - renaming options, file will not be renamed by dafault
+* rename: *String* - renaming options, file will not be renamed by default
+* background: *String* - HTML color or hex color string, not set by default
+* embed: *Boolean* - whether to use [sharp's embed](https://github.com/lovell/sharp#embed) option, default `false`
+* max: *Boolean* - whether to use [sharp's max](https://github.com/lovell/sharp#max) option, default `false`
+* flatten: *Boolean* - whether to use [sharp's flatten](https://github.com/lovell/sharp#flatten) option, default `false`
+* jpeg: *Boolean* - use JPEG format for output image, default `false`
+* webp: *Boolean* - use WebP format for output image, default `false`
+* png: *Boolean* - use PNG format for output image, default `false`
 
 Detailed description of each option can be found in the [sharp readme](https://github.com/lovell/sharp#image-transformation-options).
 

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -40,15 +40,15 @@ module.exports = function(file, config, options, cb) {
       image.resize(width, height);
     }
 
-    if (options.background) {
-      image.background(options.background);
+    if (config.background) {
+      image.background(config.background);
     }
 
-    if (options.embed) {
+    if (config.embed) {
       image.embed();
     }
 
-    if (options.max) {
+    if (config.max) {
       image.max();
     }
 
@@ -70,6 +70,18 @@ module.exports = function(file, config, options, cb) {
       image.compressionLevel(config.compressionLevel);
     } catch (err) {
       return cb(new gutil.PluginError(PLUGIN_NAME, err));
+    }
+
+    if (config.jpeg) {
+      image.jpeg();
+    }
+
+    if (config.webp) {
+      image.webp();
+    }
+
+    if (config.png) {
+      image.png();
     }
 
     image.toBuffer(function(err, buf) {

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -40,6 +40,20 @@ module.exports = function(file, config, options, cb) {
       image.resize(width, height);
     }
 
+    if (options.background) {
+      image.background(options.background);
+    }
+
+    if (options.embed) {
+      image.embed();
+    }
+
+    if (options.max) {
+      image.max();
+    }
+
+    image.flatten(config.flatten);
+
     image.withoutEnlargement(config.withoutEnlargement);
 
     try {

--- a/test/config.js
+++ b/test/config.js
@@ -72,7 +72,10 @@ describe('gulp-responsive', function() {
         quality: 96,
         progressive: true,
         compressionLevel: 8,
-        withMetadata: true
+        withMetadata: true,
+        embed: true,
+        background: 'white',
+        flatten: true
       }]);
 
       assert.equal(config.length, 1);
@@ -82,6 +85,9 @@ describe('gulp-responsive', function() {
       assert.equal(config[0].progressive, true);
       assert.equal(config[0].compressionLevel, 8);
       assert.equal(config[0].withMetadata, true);
+      assert.equal(config[0].embed, true);
+      assert.equal(config[0].background, 'white');
+      assert.equal(config[0].flatten, true);
     });
 
     it('should parse config object', function() {


### PR DESCRIPTION
I need to do a little more image transformation (transparent PNG to colored-background JPEG, for example) than is currently exposed through the plugin. This PR adds the methods I'm using.