### PR TITLE
Solution for #17 - new skipOnEnlargement config and passThroughOriginals option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,16 +144,6 @@ Default: `true`
 
 Emit error when image is enlarged.
 
-##### passThroughOriginals
-
-Type: `boolean`  
-Default: `false`
-
-Keep the original images in the stream whether they're also resized or not. Can be useful in combination with 
-`withoutEnlargement`, `errorOnEnlargement` and `skipOnEnlargement` all set to `true`, to generate sets of resized images 
-that are never larger than their corresponding original images, and where the original images are of various sizes.
-
-
 
 You can specify the following global configuration parameters in the `options` object:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Configuration unit is an object:
 * width: *Number* or *String* - width in pixels or percentage of the original, not set by default
 * height: *Number* or *String* - height in pixels or percentage of the original, not set by default
 * withoutEnlargement: *Boolean* - do not enlarge the output image, default `true`
+* skipOnEnlargement: *Boolean* - do not write an output image at all if the original image is smaller than the configured width or height, default `false`
 * max: *Boolean* - resize to the max width or height the preserving aspect ratio (both width and height have to be defined), default `false`
 * quality: *Number* - output quality for JPEG, WebP and TIFF, default `80`
 * progressive: *Boolean* - progressive (interlace) scan for JPEG and PNG output, default `false`
@@ -143,10 +144,21 @@ Default: `true`
 
 Emit error when image is enlarged.
 
+##### passThroughOriginals
+
+Type: `boolean`  
+Default: `false`
+
+Keep the original images in the stream whether they're also resized or not. Can be useful in combination with 
+`withoutEnlargement`, `errorOnEnlargement` and `skipOnEnlargement` all set to `true`, to generate sets of resized images 
+that are never larger than their corresponding original images, and where the original images are of various sizes.
+
+
 
 You can specify the following global configuration parameters in the `options` object:
 
 * withoutEnlargement: *Boolean* - do not enlarge the output image
+* skipOnEnlargement: *Boolean* - do not write an output image at all if the original image is smaller than the configured width or height
 * quality: *Number* - output quality for JPEG, WebP and TIFF
 * progressive: *Boolean* - progressive (interlace) scan for JPEG and PNG output
 * withMetadata: *Boolean* - include image metadata

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ Configuration unit is an object:
 * width: Number - not set by default
 * height: Number - not set by default
 * withoutEnlargement: Boolean - default true
+* skipOnEnlargement: Boolean - default false
 * rename: String - new file name, file will not be renamed by dafault
 
 Configuration can be provided in one of the following formats:
@@ -59,6 +60,7 @@ Configuration can be provided in one of the following formats:
 
 var defaultConfig = {
   withoutEnlargement: true,
+  skipOnEnlargement: false,
   quality: 80,
   progressive: false,
   withMetadata: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,9 @@ function gulpResponsive(config, options) {
     errorOnUnusedConfig: true,
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
-    passThroughUnused: false
+    passThroughUnused: false,
+    skipOnEnlargement: false,
+    passThroughOriginals: false
   });
 
   var notice;
@@ -38,6 +40,7 @@ function gulpResponsive(config, options) {
 
   var globalConfig = _.pick(options,
     'withoutEnlargement',
+    'skipOnEnlargement',
     'quality',
     'progressive',
     'withMetadata',
@@ -57,6 +60,10 @@ function gulpResponsive(config, options) {
 
       if (file.isStream()) {
         return done(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+      }
+
+      if (options.passThroughOriginals) {
+        this.push(file);
       }
 
       var matched = config.filter(function(conf) {
@@ -81,7 +88,9 @@ function gulpResponsive(config, options) {
           if (err) {
             return cb(err);
           }
-          that.push(newFile);
+          if (newFile) {
+            that.push(newFile);
+          }
           cb();
         });
       }, done);

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,7 @@ function gulpResponsive(config, options) {
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
     passThroughUnused: false,
-    skipOnEnlargement: false,
-    passThroughOriginals: false
+    skipOnEnlargement: false
   });
 
   var notice;
@@ -60,10 +59,6 @@ function gulpResponsive(config, options) {
 
       if (file.isStream()) {
         return done(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
-      }
-
-      if (options.passThroughOriginals) {
-        this.push(file);
       }
 
       var matched = config.filter(function(conf) {

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -26,15 +26,20 @@ module.exports = function(file, config, options, cb) {
     }
 
     if (width || height) {
-      if (options.errorOnEnlargement && config.withoutEnlargement && (width > metadata.width || height > metadata.height)) {
-        var message = 'Image must not be enlarged: ' + file.relative;
-        if (width) {
-          message += '\nreal width: ' + metadata.width + 'px, required width: ' + width + 'px';
+      if (config.withoutEnlargement && (width > metadata.width || height > metadata.height)) {
+        if (options.errorOnEnlargement) {
+          var message = 'Image must not be enlarged: ' + file.relative;
+          if (width) {
+            message += '\nreal width: ' + metadata.width + 'px, required width: ' + width + 'px';
+          }
+          if (height) {
+            message += '\nreal height: ' + metadata.height + 'px, required height: ' + height + 'px';
+          }
+          return cb(new gutil.PluginError(PLUGIN_NAME, message));
+        } else if (config.skipOnEnlargement) {
+          // pass through without resizing
+          return cb(null, null);
         }
-        if (height) {
-          message += '\nreal height: ' + metadata.height + 'px, required height: ' + height + 'px';
-        }
-        return cb(new gutil.PluginError(PLUGIN_NAME, message));
       }
 
       image.resize(width, height);

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -37,7 +37,7 @@ module.exports = function(file, config, options, cb) {
           }
           return cb(new gutil.PluginError(PLUGIN_NAME, message));
         } else if (config.skipOnEnlargement) {
-          // pass through without resizing
+          // passing a null file to the callback stops a new image being added to the pipeline for this config
           return cb(null, null);
         }
       }

--- a/test/config.js
+++ b/test/config.js
@@ -20,6 +20,17 @@ describe('gulp-responsive', function() {
       assert.equal(config[0].withoutEnlargement, true);
     });
 
+    it('should set unspecified default value for `skipOnEnlargement`', function() {
+      var config = prepareConfig([{
+        name: 'gulp.png',
+        width: 100
+      }]);
+
+      assert.equal(config.length, 1);
+      assert.equal(config[0].name, 'gulp.png');
+      assert.equal(config[0].skipOnEnlargement, false);
+    });
+
     it('should set unspecified default value for `quality`', function() {
       var config = prepareConfig([{
         name: 'gulp.png',
@@ -80,6 +91,7 @@ describe('gulp-responsive', function() {
         name: 'gulp.png',
         width: 100,
         withoutEnlargement: false,
+        skipOnEnlargement: true,
         quality: 96,
         progressive: true,
         compressionLevel: 8,
@@ -90,6 +102,7 @@ describe('gulp-responsive', function() {
       assert.equal(config.length, 1);
       assert.equal(config[0].name, 'gulp.png');
       assert.equal(config[0].withoutEnlargement, false);
+      assert.equal(config[0].skipOnEnlargement, true);
       assert.equal(config[0].quality, 96);
       assert.equal(config[0].progressive, true);
       assert.equal(config[0].compressionLevel, 8);
@@ -107,6 +120,7 @@ describe('gulp-responsive', function() {
       assert.equal(config.length, 1);
       assert.equal(config[0].name, 'gulp.png');
       assert.equal(config[0].withoutEnlargement, true);
+      assert.equal(config[0].skipOnEnlargement, false);
     });
 
     it('should parse config object of arrays', function() {
@@ -121,8 +135,10 @@ describe('gulp-responsive', function() {
       assert.equal(config.length, 2);
       assert.equal(config[0].name, 'gulp.png');
       assert.equal(config[0].withoutEnlargement, true);
+      assert.equal(config[0].skipOnEnlargement, false);
       assert.equal(config[1].name, 'gulp.png');
       assert.equal(config[1].withoutEnlargement, true);
+      assert.equal(config[1].skipOnEnlargement, false);
     });
 
   });
@@ -132,6 +148,7 @@ describe('gulp-responsive', function() {
     it('should override default values', function () {
       var globalConfig = {
         withoutEnlargement: false,
+        skipOnEnlargement: true,
         quality: 50,
         progressive: true,
         compressionLevel: 5,
@@ -145,6 +162,7 @@ describe('gulp-responsive', function() {
       assert.equal(config.length, 1);
       assert.equal(config[0].name, 'gulp.png');
       assert.equal(config[0].withoutEnlargement, false);
+      assert.equal(config[0].skipOnEnlargement, true);
       assert.equal(config[0].quality, 50);
       assert.equal(config[0].progressive, true);
       assert.equal(config[0].compressionLevel, 5);
@@ -155,6 +173,7 @@ describe('gulp-responsive', function() {
     it('should not override values specified per file', function () {
       var globalConfig = {
         withoutEnlargement: true,
+        skipOnEnlargement: false,
         quality: 50,
         progressive: false,
         compressionLevel: 5,
@@ -165,6 +184,7 @@ describe('gulp-responsive', function() {
         name: 'gulp.png',
         width: 100,
         withoutEnlargement: false,
+        skipOnEnlargement: true,
         quality: 96,
         progressive: true,
         compressionLevel: 8,
@@ -175,6 +195,7 @@ describe('gulp-responsive', function() {
       assert.equal(config.length, 1);
       assert.equal(config[0].name, 'gulp.png');
       assert.equal(config[0].withoutEnlargement, false);
+      assert.equal(config[0].skipOnEnlargement, true);
       assert.equal(config[0].quality, 96);
       assert.equal(config[0].progressive, true);
       assert.equal(config[0].compressionLevel, 8);

--- a/test/test.js
+++ b/test/test.js
@@ -216,4 +216,44 @@ describe('gulp-responsive', function() {
     stream.end();
   });
 
+  it('should pass through original files when `passThroughOriginals` is true', function(cb){
+    var expectedFile = makeFile('gulp.png');
+
+    var stream = responsive({
+      '**/*': [{
+          width: 100,
+          rename: function (path) {
+            path.dirname += '/100';
+            return path;
+          }
+        }]
+    }, {
+      passThroughOriginals: true
+    });
+
+    var counter = 0;
+
+    stream.on('data', function(file) {
+      counter++;
+      if (counter > 2) {
+        throw new Error('more than two files are provided');
+      }
+      assertFile(file);
+      if (file.path.indexOf('/100/') >= 0) {
+        assert.equal(file.path, path.join(__dirname, '/fixtures/100/gulp.png'));
+        assert.notDeepEqual(file, expectedFile);
+      } else {
+        assert.deepEqual(file, expectedFile);
+      }
+    });
+
+    stream.on('end', function() {
+      assert.equal(counter, 2);
+      cb();
+    });
+
+    stream.write(expectedFile);
+    stream.end();
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -216,44 +216,4 @@ describe('gulp-responsive', function() {
     stream.end();
   });
 
-  it('should pass through original files when `passThroughOriginals` is true', function(cb){
-    var expectedFile = makeFile('gulp.png');
-
-    var stream = responsive({
-      '**/*': [{
-          width: 100,
-          rename: function (path) {
-            path.dirname += '/100';
-            return path;
-          }
-        }]
-    }, {
-      passThroughOriginals: true
-    });
-
-    var counter = 0;
-
-    stream.on('data', function(file) {
-      counter++;
-      if (counter > 2) {
-        throw new Error('more than two files are provided');
-      }
-      assertFile(file);
-      if (file.path.indexOf('/100/') >= 0) {
-        assert.equal(file.path, path.join(__dirname, '/fixtures/100/gulp.png'));
-        assert.notDeepEqual(file, expectedFile);
-      } else {
-        assert.deepEqual(file, expectedFile);
-      }
-    });
-
-    stream.on('end', function() {
-      assert.equal(counter, 2);
-      cb();
-    });
-
-    stream.write(expectedFile);
-    stream.end();
-  });
-
 });


### PR DESCRIPTION
I also wanted the behaviour described in #17. Here's the config I'm using:

    var _ = require('lodash');
    ...
    .pipe(plugins.responsive({
        '**/*.+(png|jpg|jpeg)': _.map([320, 640, 960, 1280, 1600, 1920, 2560, 3200], function(width) {
            return {
                width: width,
                rename: function (path) {
                    path.dirname += '/responsive/' + width;
                    return path;
                }
            };
        })
    }, {
        errorOnUnusedImage: false,
        passThroughUnused: true,
        withoutEnlargement: true,
        errorOnEnlargement: false,
        skipOnEnlargement: true,
        passThroughOriginals: true
    }))

So given the following images:

- `background.jpg` (3000px wide)
- `foreground.jpg` (1200px wide)

I get with the following in my output directory:

- `background.jpg` (3000px wide)
- `foreground.jpg` (1200px wide)
- `responsive/320/background.jpg` (320px wide)
- `responsive/320/foreground.jpg` (320px wide)
- `responsive/640/background.jpg` (640px wide)
- `responsive/640/foreground.jpg` (640px wide)
- `responsive/960/background.jpg` (960px wide)
- `responsive/960/foreground.jpg` (960px wide)
- `responsive/1280/background.jpg` (1280px wide)
- `responsive/1600/background.jpg` (1600px wide)
- `responsive/1920/background.jpg` (1920px wide)
- `responsive/2560/background.jpg` (2560px wide)

Notice that there is no `foreground.jpg` generated in the `responsive/1280` folder because that would have meant either enlarging (which `withoutEnlargement: true` prevents) or copying the file unchanged (which the new option `skipOnEnlargement: true` prevents). And the original files are also copied through because of the new `passThroughOriginals: true` option.