### PR TITLE
Update documentation with new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,34 @@ Configuration can be provided in one of the following formats:
 
 Configuration unit is an object:
 
-* name: *String* - filename glob pattern
-* width: *Number* or *String* - width in pixels or percentage of the original, not set by default
-* height: *Number* or *String* - height in pixels or percentage of the original, not set by default
-* withoutEnlargement: *Boolean* - do not enlarge the output image, default `true`
-* skipOnEnlargement: *Boolean* - do not write an output image at all if the original image is smaller than the configured width or height, default `false`
-* max: *Boolean* - resize to the max width or height the preserving aspect ratio (both width and height have to be defined), default `false`
-* quality: *Number* - output quality for JPEG, WebP and TIFF, default `80`
-* progressive: *Boolean* - progressive (interlace) scan for JPEG and PNG output, default `false`
-* withMetadata: *Boolean* - include image metadata, default `false`
-* compressionLevel: *Number* - zlib compression level for PNG, default `6`
-* rename: *String*, *Object* or *Function* - renaming options, file will not be renamed by dafault
+* name: *String* — filename glob pattern
+* width: *Number* or *String* — width in pixels or percentage of the original, not set by default
+* height: *Number* or *String* — height in pixels or percentage of the original, not set by default
+* withoutEnlargement: *Boolean* — do not enlarge the output image, default `true`
+* skipOnEnlargement: *Boolean* — do not write an output image at all if the original image is smaller than the configured width or height, default `false`
+* min: *Boolean* — preserving aspect ratio, resize the image to be as small as possible while ensuring its dimensions are greater than or equal to the `width` and `height` specified
+* max: *Boolean* — resize to the max width or height the preserving aspect ratio (both `width` and `height` have to be defined), default `false`
+* quality: *Number* — output quality for JPEG, WebP and TIFF, default `80`
+* progressive: *Boolean* — progressive (interlace) scan for JPEG and PNG output, default `false`
+* withMetadata: *Boolean* — include image metadata, default `false`
+* compressionLevel: *Number* — zlib compression level for PNG, default `6`
+* rename: *String*, *Object* or *Function* — renaming options, file will not be renamed by dafault
+* format: *String* — output format `jpeg`, `png`, `webp` or `raw`, default is `null`
+* crop: Crop the resized image to the exact size specified, default is `false`
+* embed: Preserving aspect ratio, resize the image to the maximum `width` or `height` specified then `embed` on a `background` of the exact `width` and `height` specified, default is `false`
+* ignoreAspectRatio: *Boolean* — Ignoring the aspect ratio of the input, stretch the image to the exact `width` and/or `height` provided via `resize`, default is `false`
+* interpolation: 'default is `bicubic`'
+* background: *String* — Set the background for the embed and flatten operations, '#default is `fff`'
+* flatten: *Boolean* — Merge alpha transparency channel, if any, with `background`, default is `false`
+* rotate: *Boolean* — Rotate the output image by either an explicit angle or auto-orient based on the EXIF `Orientation` tag, default is `false`
+* flip: *Boolean* — Flip the image about the vertical Y axis. This always occurs after rotation, if any. The use of `flip` implies the removal of the EXIF `Orientation` tag, if any. Default is `false`
+* flop: *Boolean* — Flop the image about the horizontal X axis. This always occurs after rotation, if any. The use of `flop` implies the removal of the EXIF `Orientation` tag, if any. Default is `false`
+* blur: *Boolean* — When used without parameters, performs a fast, mild blur of the output image. This typically reduces performance by 10%. Default is `false`
+* sharpen: *Boolean* — When used without parameters, performs a fast, mild sharpen of the output image. This typically reduces performance by 10%. Default is `false`
+* gamma: *Boolean* — Apply a gamma correction by reducing the encoding (darken) pre-resize at a factor of `1/gamma` then increasing the encoding (brighten) post-resize at a factor of `gamma`. Default is `false`
+* grayscale: *Boolean* — Convert to 8-bit greyscale; 256 shades of grey, default is `false`
+* normalize: *Boolean* — Enhance output image contrast by stretching its luminance to cover the full dynamic range. This typically reduces performance by 30%. Default is `false`
+* withoutChromaSubsampling: *Boolean* — Disable the use of [chroma subsampling](http://en.wikipedia.org/wiki/Chroma_subsampling) with JPEG output (4:4:4), default is `false`
 
 Detailed description of each option can be found in the [sharp readme](https://github.com/lovell/sharp#image-transformation-options).
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Configuration unit is an object:
 * progressive: *Boolean* — progressive (interlace) scan for JPEG and PNG output, default `false`
 * withMetadata: *Boolean* — include image metadata, default `false`
 * compressionLevel: *Number* — zlib compression level for PNG, default `6`
-* rename: *String*, *Object* or *Function* — renaming options, file will not be renamed by dafault
+* rename: *String*, *Object* or *Function* — renaming options, file will not be renamed by default. When `extname` is specified, output format is parsed from extension. You can override this autodetection with `format` option.
 * format: *String* — output format `jpeg`, `png`, `webp` or `raw`, default is `null`
 * crop: Crop the resized image to the exact size specified, default is `false`
 * embed: Preserving aspect ratio, resize the image to the maximum `width` or `height` specified then `embed` on a `background` of the exact `width` and `height` specified, default is `false`


### PR DESCRIPTION
Options are guessed from Sharp documentation and this file
https://github.com/mahnunchik/gulp-responsive/blob/next/lib/config.js#L88

Some could be wrong, but could be a good start too.

There is a conflict between `Boolean` options in your config and other types in Sharp. For example:

`tile: false` in gulp-responsive and `tile([size], [overlap])` in Sharp.