### PR TITLE
New option: silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ Default: `true`
 
 Emit the error when image is enlarged.
 
+##### stats
+
+Type: `Boolean`  
+Default: `true`
+
+Show statistics after the run — how many images were created, how many were matched and how many were in the run in total.
+
+##### silent
+
+Type: `Boolean`
+Default: `false`
+
+Silence messages and stats if 0 images were created. If you wish for complete silence, activate `options.silent` and disable `options.stats`.
+
 > You can specify **global default value** for any of [configuration option](#configuration-unit).
 
 ```js

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Installation
 
 
-`gulp-responsive` depends on [sharp](https://github.com/lovell/sharp). Sharp is one of the fastest Node.js module for resizing JPEG, PNG, WebP and TIFF images.
+`gulp-responsive` depends on [sharp](https://github.com/lovell/sharp). Sharp is one of the fastest Node.js modules for resizing JPEG, PNG, WebP and TIFF images.
 
 If you are using Mac OS then before installing `gulp-responsive` you should install the [libvips](https://github.com/jcupitt/libvips) library. Further information and instructions can be found in the [sharp installation guide](http://sharp.dimens.io/en/stable/install/).
 
@@ -157,7 +157,7 @@ Configuration unit is an object:
 Detailed description of each option can be found in the [sharp API documentation](http://sharp.dimens.io/en/stable/api/).
 
 ##### Renaming
-Renaming is implemented by [rename](https://www.npmjs.com/package/rename) module. Options are correspond options of [gulp-rename](https://www.npmjs.com/package/gulp-rename) module.
+Renaming is implemented by the [rename](https://www.npmjs.com/package/rename) module. Options correspond with options of [gulp-rename](https://www.npmjs.com/package/gulp-rename).
 
 #### options
 
@@ -199,12 +199,12 @@ Show statistics after the run — how many images were created, how many were ma
 
 ##### silent
 
-Type: `Boolean`
+Type: `Boolean`  
 Default: `false`
 
-Silence messages and stats if 0 images were created. If you wish for complete silence, activate `options.silent` and disable `options.stats`.
+Silence messages and stats if 0 images were created. If you wish to supress all messages and stats, set the `options.stats` to `false` as well.
 
-> You can specify **global default value** for any of [configuration option](#configuration-unit).
+> You can specify **global default value** for any of the [configuration options](#configuration-unit).
 
 ```js
 gulp.task('default', function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,8 @@ function gulpResponsive(config, options) {
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
     passThroughUnused: false,
-    silent: false
+    silent: false,
+    stats: true
   });
 
   config = prepareConfig(config || [], options);
@@ -93,7 +94,7 @@ function gulpResponsive(config, options) {
         return !conf.mathed;
       });
 
-      if (options.silent && statistics.total > 0){
+      if (options.stats && !(options.silent && statistics.total === 0)){
         var msg =
           'Created ' + statistics.created + ' ' + plur('image', statistics.created) +
           gutil.colors.dim.white(' (matched ' + statistics.matched + ' of ' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,11 +59,15 @@ function gulpResponsive(config, options) {
         } else if (options.passThroughUnused) {
           this.push(file);
           statistics.unmatchedPassed++;
-          gutil.log(PLUGIN_NAME + ': (pass through without changes)', gutil.colors.magenta(message));
+          if (!options.silent){
+            gutil.log(PLUGIN_NAME + ': (pass through without changes)', gutil.colors.magenta(message));
+          }
           return done();
         }
         statistics.unmatchedBlocked++;
-        gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.magenta(message));
+        if (!options.silent){
+          gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.magenta(message));
+        }
         return done();
       }
 
@@ -88,7 +92,7 @@ function gulpResponsive(config, options) {
         return !conf.mathed;
       });
 
-      if (notMatched.length > 0) {
+      if (notMatched.length > 0 && (!options.silent || options.errorOnUnusedConfig)) {
         var message = 'Available images do not match the following config:';
         notMatched.forEach(function(conf) {
           message += '\n  - `' + conf.name + '`';

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,15 @@ var PLUGIN_NAME = require('../package.json').name;
 
 function gulpResponsive(config, options) {
 
+  var statistics = {
+    total: 0,
+    matched: 0,
+    created: 0,
+    unmatched: 0,
+    unmatchedBlocked: 0,
+    unmatchedPassed: 0
+  };
+
   options = _.defaults({}, options, {
     errorOnUnusedConfig: true,
     errorOnUnusedImage: true,
@@ -36,23 +45,28 @@ function gulpResponsive(config, options) {
         return done(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
       }
 
+      statistics.total++;
       var matched = config.filter(function(conf) {
         return minimatch(file.relative, conf.name);
       });
 
       if (matched.length === 0) {
+        statistics.unmatched++;
         var message = 'File `' + file.relative + '`: Image does not match any config';
         if (options.errorOnUnusedImage) {
           return done(new gutil.PluginError(PLUGIN_NAME, message));
         } else if (options.passThroughUnused) {
           this.push(file);
+          statistics.unmatchedPassed++;
           gutil.log(PLUGIN_NAME + ': (pass through without changes)', gutil.colors.magenta(message));
           return done();
         }
+        statistics.unmatchedBlocked++;
         gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.magenta(message));
         return done();
       }
 
+      statistics.matched++;
       async.each(matched, function(conf, cb) {
         // config item matched (can be matched multiple times)
         conf.mathed = true;
@@ -63,6 +77,7 @@ function gulpResponsive(config, options) {
           }
           if (newFile) {
             that.push(newFile);
+            statistics.created++;
           }
           cb();
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function gulpResponsive(config, options) {
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
     passThroughUnused: false,
-    silent: true,
+    silent: false,
     stats: true
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function gulpResponsive(config, options) {
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
     passThroughUnused: false,
-    silent: false,
+    silent: true,
     stats: true
   });
 
@@ -94,7 +94,7 @@ function gulpResponsive(config, options) {
         return !conf.mathed;
       });
 
-      if (options.stats && !(options.silent && statistics.total === 0)){
+      if (options.stats && !(options.silent && statistics.created === 0)){
         var msg =
           'Created ' + statistics.created + ' ' + plur('image', statistics.created) +
           gutil.colors.dim.white(' (matched ' + statistics.matched + ' of ' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var through2 = require('through2');
 var minimatch = require('minimatch');
 var async = require('async');
 var _ = require('lodash');
+var plur = require('plur');
 
 var sharpVinyl = require('./sharp');
 var prepareConfig = require('./config');
@@ -91,6 +92,15 @@ function gulpResponsive(config, options) {
       var notMatched = config.filter(function(conf) {
         return !conf.mathed;
       });
+
+      if (options.silent && statistics.total > 0){
+        var msg =
+          'Created ' + statistics.created + ' ' + plur('image', statistics.created) +
+          gutil.colors.dim.white(' (matched ' + statistics.matched + ' of ' +
+          statistics.total + ' ' + plur('image', statistics.total) + ')');
+
+        gutil.log(PLUGIN_NAME + ':', gutil.colors.green(msg));
+      }
 
       if (notMatched.length > 0 && (!options.silent || options.errorOnUnusedConfig)) {
         var message = 'Available images do not match the following config:';

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,8 @@ function gulpResponsive(config, options) {
     errorOnUnusedConfig: true,
     errorOnUnusedImage: true,
     errorOnEnlargement: true,
-    passThroughUnused: false
+    passThroughUnused: false,
+    silent: false
   });
 
   config = prepareConfig(config || [], options);

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -50,11 +50,15 @@ module.exports = function(file, config, options, cb) {
         if (options.errorOnEnlargement) {
           return cb(new gutil.PluginError(PLUGIN_NAME, message));
         } else if (config.skipOnEnlargement) {
-          gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.red(message));
+          if (!options.silent){
+            gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.red(message));
+          }
           // passing a null file to the callback stops a new image being added to the pipeline for this config
           return cb(null, null);
         }
-        gutil.log(PLUGIN_NAME + ': (skip for enlargement)', gutil.colors.yellow(message));
+        if (!options.silent){
+          gutil.log(PLUGIN_NAME + ': (skip for enlargement)', gutil.colors.yellow(message));
+        }
       }
     }
 
@@ -158,7 +162,9 @@ module.exports = function(file, config, options, cb) {
         contents: buf
       });
 
-      gutil.log(PLUGIN_NAME + ':', gutil.colors.green(file.relative + ' -> ' + newFile.relative));
+      if (!options.silent){
+        gutil.log(PLUGIN_NAME + ':', gutil.colors.green(file.relative + ' -> ' + newFile.relative));
+      }
 
       cb(null, newFile);
     });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-util": "^3.0.1",
     "lodash": "^4.5.0",
     "minimatch": "^3.0.0",
+    "plur": "^2.1.2",
     "rename": "^1.0.3",
     "sharp": "^0.13.0",
     "through2": "^2.0.0"


### PR DESCRIPTION
Hi,

thanks for this great gulp plugin. Unfortunately, it's far too talkative for me :smile:, so I added a 'silent' option. And since I'd like to have at least *some* feedback, I added a 'totals' output.

Changes:
* silence all console messages
* count processed files (and basic statistics: matched/unmatched, etc.)
* output a result of processing: 'Created X images (matched Y of Z images)'
* If 0 files were matched, be completely silent.

All tests pass (well, except --webp, because I don't have libvips with webp compiled), and the silent mode must be activated (original verbose mode is the default mode) so it's completely backwards compatible.