### PR TITLE
Update sharp to 0.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "minimatch": "^3.0.0",
     "plur": "^2.1.2",
     "rename": "^1.0.3",
-    "sharp": "^0.17.0",
+    "sharp": "^0.17.3",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes failing build on Centos7 x64 using Node LTS.

Original issue: https://github.com/lovell/sharp/issues/802