### PR TITLE
Fix extractBeforeResize & extractAfterResize options passing

### DIFF
--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -65,7 +65,7 @@ module.exports = function(file, config, options, cb) {
     try {
       if (config.extractBeforeResize) {
         extract = config.extractBeforeResize;
-        image.extract(extract.top, extract.left, extract.width, extract.height);
+        image.extract(extract);
       }
 
       if (config.interpolation) {
@@ -80,7 +80,7 @@ module.exports = function(file, config, options, cb) {
 
       if (config.extractAfterResize) {
         extract = config.extractAfterResize;
-        image.extract(extract.top, extract.left, extract.width, extract.height);
+        image.extract(extract);
       }
 
       if (config.crop !== false) {

--- a/test/extract.js
+++ b/test/extract.js
@@ -1,0 +1,39 @@
+/*global describe, it */
+
+'use strict';
+
+var responsive = require('../');
+
+var helpers = require('./helpers');
+var makeFile = helpers.makeFile;
+var assertFile = helpers.assertFile;
+
+describe('gulp-responsive', function () {
+
+  function runTest(config, cb) {
+    var stream = responsive(config);
+    stream.on('end', function () {
+      cb();
+    });
+    stream.on('data', function (file) {
+      assertFile(file);
+    });
+    stream.write(makeFile('gulp.png'));
+    stream.end();
+  }
+
+  it('should let you extract before resize', function (cb) {
+    var config = [{
+      name: 'gulp.png',
+      extractBeforeResize: {top:0, left: 0, width: 10, height: 10}
+    }];
+    runTest(config, cb);
+  });
+  it('should let you extract after resize', function (cb) {
+    var config = [{
+      name: 'gulp.png',
+      extractAfterResize: {top:0, left: 0, width: 10, height: 10}
+    }];
+    runTest(config, cb);
+  });
+});


### PR DESCRIPTION
The extractBeforeResize and extractAfterResize operations did not work, since they passed arguments to Sharp incorrectly