### PR TITLE
GutilReplace deprecated gulp-util package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var chalk = require('chalk');
+var flog = require('fancy-log');
 var through2 = require('through2');
 var minimatch = require('minimatch');
+var PluginError = require('plugin-error');
 var async = require('async');
 var _ = require('lodash');
 var plur = require('plur');
@@ -11,8 +13,6 @@ var sharpVinyl = require('./sharp');
 var prepareConfig = require('./config');
 
 var PLUGIN_NAME = require('../package.json').name;
-
-
 
 function gulpResponsive(config, options) {
 
@@ -45,7 +45,7 @@ function gulpResponsive(config, options) {
       }
 
       if (file.isStream()) {
-        return done(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+        return done(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
       }
 
       statistics.total++;
@@ -57,18 +57,18 @@ function gulpResponsive(config, options) {
         statistics.unmatched++;
         var message = 'File `' + file.relative + '`: Image does not match any config';
         if (options.errorOnUnusedImage) {
-          return done(new gutil.PluginError(PLUGIN_NAME, message));
+          return done(new PluginError(PLUGIN_NAME, message));
         } else if (options.passThroughUnused) {
           this.push(file);
           statistics.unmatchedPassed++;
           if (!options.silent){
-            gutil.log(PLUGIN_NAME + ': (pass through without changes)', gutil.colors.magenta(message));
+            flog(PLUGIN_NAME + ': (pass through without changes)', chalk.magenta(message));
           }
           return done();
         }
         statistics.unmatchedBlocked++;
         if (!options.silent){
-          gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.magenta(message));
+          flog(PLUGIN_NAME + ': (skip for processing)', chalk.magenta(message));
         }
         return done();
       }
@@ -97,10 +97,10 @@ function gulpResponsive(config, options) {
       if (options.stats && !(options.silent && statistics.created === 0)){
         var msg =
           'Created ' + statistics.created + ' ' + plur('image', statistics.created) +
-          gutil.colors.dim.white(' (matched ' + statistics.matched + ' of ' +
+          chalk.dim.white(' (matched ' + statistics.matched + ' of ' +
           statistics.total + ' ' + plur('image', statistics.total) + ')');
 
-        gutil.log(PLUGIN_NAME + ':', gutil.colors.green(msg));
+        flog(PLUGIN_NAME + ':', chalk.green(msg));
       }
 
       if (notMatched.length > 0 && (!options.silent || options.errorOnUnusedConfig)) {
@@ -109,9 +109,9 @@ function gulpResponsive(config, options) {
           message += '\n  - `' + conf.name + '`';
         });
         if (options.errorOnUnusedConfig) {
-          return cb(new gutil.PluginError(PLUGIN_NAME, message));
+          return cb(new PluginError(PLUGIN_NAME, message));
         } else {
-          gutil.log(PLUGIN_NAME + ':', gutil.colors.magenta(message));
+          flog(PLUGIN_NAME + ':', chalk.magenta(message));
         }
       }
       cb();

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -1,9 +1,12 @@
 'use strict';
 
 var sharp = require('sharp');
-var gutil = require('gulp-util');
+var chalk = require('chalk');
+var flog = require('fancy-log');
 var path = require('path');
+var PluginError = require('plugin-error');
 var rename = require('rename');
+var Vinyl = require('vinyl');
 var size = require('./size');
 var format = require('./format');
 
@@ -15,7 +18,7 @@ module.exports = function(file, config, options, cb) {
 
   image.metadata(function(err, metadata) {
     if (err) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, errPrefix + err.message));
+      return cb(new PluginError(PLUGIN_NAME, errPrefix + err.message));
     }
 
     var width, height, extract, toFormat;
@@ -35,7 +38,7 @@ module.exports = function(file, config, options, cb) {
       width = size(config.width, metadata.width);
       height = size(config.height, metadata.height);
     } catch  (err){
-      return cb(new gutil.PluginError(PLUGIN_NAME, errPrefix + err.message));
+      return cb(new PluginError(PLUGIN_NAME, errPrefix + err.message));
     }
 
     if (width || height) {
@@ -48,16 +51,16 @@ module.exports = function(file, config, options, cb) {
           message += '\n  real height: ' + metadata.height + 'px, required height: ' + height + 'px';
         }
         if (options.errorOnEnlargement) {
-          return cb(new gutil.PluginError(PLUGIN_NAME, message));
+          return cb(new PluginError(PLUGIN_NAME, message));
         } else if (config.skipOnEnlargement) {
           if (!options.silent){
-            gutil.log(PLUGIN_NAME + ': (skip for processing)', gutil.colors.red(message));
+            flog(PLUGIN_NAME + ': (skip for processing)', chalk.red(message));
           }
           // passing a null file to the callback stops a new image being added to the pipeline for this config
           return cb(null, null);
         }
         if (!options.silent){
-          gutil.log(PLUGIN_NAME + ': (skip for enlargement)', gutil.colors.yellow(message));
+          flog(PLUGIN_NAME + ': (skip for enlargement)', chalk.yellow(message));
         }
       }
     }
@@ -70,7 +73,7 @@ module.exports = function(file, config, options, cb) {
 
       if (config.interpolation) {
         config.interpolator = config.interpolation;
-        gutil.log(PLUGIN_NAME + ':', gutil.colors.red('`interpolation` option is deprecated, use `interpolator` instead'));
+        flog(PLUGIN_NAME + ':', chalk.red('`interpolation` option is deprecated, use `interpolator` instead'));
       }
 
       image.resize(width, height, {
@@ -153,16 +156,16 @@ module.exports = function(file, config, options, cb) {
 
     } catch (err) {
       err.message = errPrefix + err.message;
-      return cb(new gutil.PluginError(PLUGIN_NAME, err, {showStack: true}));
+      return cb(new PluginError(PLUGIN_NAME, err, {showStack: true}));
     }
 
     image.toBuffer(function(err, buf) {
       if (err) {
         err.message = errPrefix + err.message;
-        return cb(new gutil.PluginError(PLUGIN_NAME, err, {showStack: true}));
+        return cb(new PluginError(PLUGIN_NAME, err, {showStack: true}));
       }
 
-      var newFile = new gutil.File({
+      var newFile = new Vinyl({
         cwd: file.cwd,
         base: file.base,
         path: filePath,
@@ -170,7 +173,7 @@ module.exports = function(file, config, options, cb) {
       });
 
       if (!options.silent){
-        gutil.log(PLUGIN_NAME + ':', gutil.colors.green(file.relative + ' -> ' + newFile.relative));
+        flog(PLUGIN_NAME + ':', chalk.green(file.relative + ' -> ' + newFile.relative));
       }
 
       cb(null, newFile);

--- a/package.json
+++ b/package.json
@@ -33,13 +33,16 @@
   ],
   "dependencies": {
     "async": "^2.0.1",
-    "gulp-util": "^3.0.1",
+    "chalk": "^2.3.0",
+    "fancy-log": "^1.3.2",
     "lodash": "^4.5.0",
     "minimatch": "^3.0.0",
+    "plugin-error": "^0.1.2",
     "plur": "^2.1.2",
     "rename": "^1.0.3",
     "sharp": "^0.17.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "file-type": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,21 +32,21 @@
     "gulp-responsive-images"
   ],
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^2.6.0",
     "chalk": "^2.3.0",
     "fancy-log": "^1.3.2",
-    "lodash": "^4.5.0",
-    "minimatch": "^3.0.0",
+    "lodash": "^4.17.4",
+    "minimatch": "^3.0.4",
     "plugin-error": "^0.1.2",
     "plur": "^2.1.2",
-    "rename": "^1.0.3",
+    "rename": "^1.0.4",
     "sharp": "^0.17.0",
-    "through2": "^2.0.0",
+    "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },
   "devDependencies": {
-    "file-type": "^4.0.0",
-    "jshint": "^2.5.10",
-    "mocha": "^3.0.2"
+    "file-type": "^7.4.0",
+    "jshint": "^2.9.5",
+    "mocha": "^4.1.0"
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var flog = require('fancy-log');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
+var Vinyl = require('vinyl');
 
 function makeFile(name, file) {
   if (!file) {
     file = name;
   }
-  return new gutil.File({
+  return new Vinyl({
     base: path.join(__dirname, '/fixtures'),
     path:  path.join(__dirname, '/fixtures/', name),
     contents: fs.readFileSync(path.join(__dirname, '/fixtures/', file))
@@ -28,5 +29,5 @@ exports.assertFile = assertFile;
 
 // Force mute gulp logger in test environment
 if (process.env.NODE_ENV === 'test') {
-  gutil.log = function () {};
+  flog = function () {};
 }


### PR DESCRIPTION
With gulp4 the gulp-util package is officially deprecated. This PR replaces its occurences with suggested alternatives (https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5)
See also gulpjs/gulp-util#143