### PR TITLE
Replace deprecated `util.isArray()`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,6 @@
 /*jshint -W083 */
 'use strict';
 
-var util = require('util');
 var _ = require('lodash');
 
 /*
@@ -95,10 +94,10 @@ var defaultConfig = {
 function prepareConfig(config, globalConfig) {
   var preparedConfig = [];
 
-  if (!util.isArray(config)) {
+  if (!Array.isArray(config)) {
     for (var name in config) {
       if (config.hasOwnProperty(name)) {
-        if (util.isArray(config[name])) {
+        if (Array.isArray(config[name])) {
           config[name].forEach(function(conf) {
             preparedConfig.push(_.defaults({name: name}, conf, globalConfig, defaultConfig));
           });


### PR DESCRIPTION
[`util.isArray()`](https://nodejs.org/api/util.html#util_util_isarray_object) has been deprecated in Node for a while. It's advised to use `Array.isArray()` instead.