### PR TITLE
Remove `interpolator` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Configuration unit is an object:
 * [**crop**](http://sharp.dimens.io/en/stable/api-resize/#crop): Crop the resized image to the exact size specified, default is `false`.
 * [**embed**](http://sharp.dimens.io/en/stable/api-resize/#embed): Preserving aspect ratio, resize the image to the maximum `width` or `height` specified then `embed` on a `background` of the exact `width` and `height` specified, default is `false`.
 * [**ignoreAspectRatio**](http://sharp.dimens.io/en/stable/api-resize/#ignoreaspectratio): *Boolean* — Ignoring the aspect ratio of the input, stretch the image to the exact `width` and/or `height` provided via `resize`, default is `false`.
-* [**interpolator**](http://sharp.dimens.io/en/stable/api/#resizewidth-height-options): *String* — The interpolator to use for image **enlargement**, defaulting to `bicubic`.
 * [**kernel**](http://sharp.dimens.io/en/stable/api/#resizewidth-height-options): *String* — The kernel to use for image **reduction**, defaulting to `lanczos3`.
 * [**background**](http://sharp.dimens.io/en/stable/api-colour/#background): [*Color*](https://www.npmjs.com/package/color) — Set the background for the embed and flatten operations, '#default is `fff`'.
 * [**flatten**](http://sharp.dimens.io/en/stable/api-operation/#flatten): *Boolean* — Merge alpha transparency channel, if any, with `background`, default is `false`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,6 @@ var defaultConfig = {
   withoutEnlargement: true,
   skipOnEnlargement: false,
   ignoreAspectRatio: false,
-  interpolator: 'bicubic',
   kernel: 'lanczos3',
   extractBeforeResize: false,
   extractAfterResize: false,

--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -71,13 +71,7 @@ module.exports = function(file, config, options, cb) {
         image.extract(extract);
       }
 
-      if (config.interpolation) {
-        config.interpolator = config.interpolation;
-        flog(PLUGIN_NAME + ':', chalk.red('`interpolation` option is deprecated, use `interpolator` instead'));
-      }
-
       image.resize(width, height, {
-        interpolator: config.interpolator,
         kernel: config.kernel,
       });
 

--- a/test/config.js
+++ b/test/config.js
@@ -23,7 +23,6 @@ describe('gulp-responsive', function () {
       assert.equal(config[0].withoutEnlargement, true);
       assert.equal(config[0].skipOnEnlargement, false);
       assert.equal(config[0].ignoreAspectRatio, false);
-      assert.equal(config[0].interpolator, 'bicubic');
       assert.equal(config[0].kernel, 'lanczos3');
       assert.equal(config[0].extractBeforeResize, false);
       assert.equal(config[0].extractAfterResize, false);
@@ -60,7 +59,6 @@ describe('gulp-responsive', function () {
         withoutEnlargement: 'test',
         skipOnEnlargement: 'test',
         ignoreAspectRatio: 'test',
-        interpolator: 'test',
         kernel: 'test',
         extractBeforeResize: 'test',
         extractAfterResize: 'test',
@@ -94,7 +92,6 @@ describe('gulp-responsive', function () {
       assert.equal(config[0].withoutEnlargement, 'test');
       assert.equal(config[0].skipOnEnlargement, 'test');
       assert.equal(config[0].ignoreAspectRatio, 'test');
-      assert.equal(config[0].interpolator, 'test');
       assert.equal(config[0].kernel, 'test');
       assert.equal(config[0].extractBeforeResize, 'test');
       assert.equal(config[0].extractAfterResize, 'test');
@@ -179,7 +176,6 @@ describe('gulp-responsive', function () {
         withoutEnlargement: 'test',
         skipOnEnlargement: 'test',
         ignoreAspectRatio: 'test',
-        interpolator: 'test',
         kernel: 'test',
         extractBeforeResize: 'test',
         extractAfterResize: 'test',
@@ -216,7 +212,6 @@ describe('gulp-responsive', function () {
       assert.equal(config[0].withoutEnlargement, 'test');
       assert.equal(config[0].skipOnEnlargement, 'test');
       assert.equal(config[0].ignoreAspectRatio, 'test');
-      assert.equal(config[0].interpolator, 'test');
       assert.equal(config[0].kernel, 'test');
       assert.equal(config[0].extractBeforeResize, 'test');
       assert.equal(config[0].extractAfterResize, 'test');
@@ -250,7 +245,6 @@ describe('gulp-responsive', function () {
         withoutEnlargement: 'global',
         skipOnEnlargement: 'global',
         ignoreAspectRatio: 'global',
-        interpolator: 'global',
         kernel: 'global',
         extractBeforeResize: 'global',
         extractAfterResize: 'global',
@@ -284,7 +278,6 @@ describe('gulp-responsive', function () {
         withoutEnlargement: 'test',
         skipOnEnlargement: 'test',
         ignoreAspectRatio: 'test',
-        interpolator: 'test',
         kernel: 'test',
         extractBeforeResize: 'test',
         extractAfterResize: 'test',
@@ -318,7 +311,6 @@ describe('gulp-responsive', function () {
       assert.equal(config[0].withoutEnlargement, 'test');
       assert.equal(config[0].skipOnEnlargement, 'test');
       assert.equal(config[0].ignoreAspectRatio, 'test');
-      assert.equal(config[0].interpolator, 'test');
       assert.equal(config[0].kernel, 'test');
       assert.equal(config[0].extractBeforeResize, 'test');
       assert.equal(config[0].extractAfterResize, 'test');


### PR DESCRIPTION
The `interpolator` option for image enlargement was [removed in sharp v0.19](http://sharp.dimens.io/en/stable/changelog/#v0190-11th-january-2018). This PR removes it from `gulp-responsive` as well, as it no longer has any effect with sharp being at v0.20.1.