### PR TITLE
Allow passing undocumented output options

### DIFF
--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -154,29 +154,24 @@ module.exports = function(file, config, options, cb) {
       image.withMetadata(config.withMetadata);
       image.tile(config.tile);
 
-      var outputOptions;
+      if (config.withoutChromaSubsampling) {
+        config.chromaSubsampling = '4.4.4';
+      }
       switch (toFormat) {
         case 'jpeg':
-          outputOptions = { quality: config.quality, progressive: config.progressive };
-          if (config.withoutChromaSubsampling) {
-            outputOptions.chromaSubsampling = '4.4.4';
-          }
-          image.jpeg(outputOptions);
+          image.jpeg(config);
           break;
         case 'png':
-          outputOptions = { compressionLevel: config.compressionLevel, progressive: config.progressive };
-          image.png(outputOptions);
+          image.png(config);
           break;
         case 'webp':
-          outputOptions = { quality: config.quality };
-          image.webp(outputOptions);
+          image.webp(config);
           break;
         case 'tiff':
-          outputOptions = { quality: config.quality };
-          image.tiff(outputOptions);
+          image.tiff(config);
           break;
         default:
-          image.toFormat(format);
+          image.toFormat(format, config);
           break;
       }
 


### PR DESCRIPTION
Currently, filetype-specific output options that aren't mentioned in the readme of this plugin (e.g. [`lossless` for `.webp`](http://sharp.pixelplumbing.com/en/stable/api-output/#webp)) don't get passed on to sharp. This PR adds support for these undocumented options.

Closes #81.