### PR TITLE
Avoid renaming extname in case of jpg or jpe

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -6,9 +6,11 @@ module.exports = function(filePath) {
   var extname = path.extname(filePath);
   switch (extname) {
     case '.jpeg':
-    case '.jpg':
-    case '.jpe':
       return 'jpeg';
+    case '.jpg':
+      return 'jpg';
+    case '.jpe':
+      return 'jpe';
     case '.png':
       return 'png';
     case '.webp':


### PR DESCRIPTION
This automatic rename for .jpg and jpe in .jpeg is problematic because it's hardcoded and sometimes you don't want it (as in my case, when using this package in combination with metalsmith).
As the package propose an option to rename files and extension, this is not required.
Could you consider merging this PR? If you prefer, another option could be to add some config var to disable this behaviour.
