### PR TITLE
Fix options passed to Sharp .toFormat()

### DIFF
--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -180,7 +180,7 @@ module.exports = function (file, config, options) {
             clone.tiff(config);
             break;
           default:
-            clone.toFormat(format, config);
+            clone.toFormat(value, config);
             break;
         }
 


### PR DESCRIPTION
Trying to set the format option to `"raw"` or `{ "id": "raw" }` yields the following error:

```
Message:
    File `portrait.png`: Unsupported output format function(filePath) {
  var extname = path.extname(filePath);
  switch (extname) {
    case '.jpeg':
    case '.jpg':
    case '.jpe':
      return 'jpeg';
    case '.png':
      return 'png';
    case '.webp':
      return 'webp';
    default:
      return 'unsupported';
  }
}
```

This is because the `format` function is passed to the Sharp `.toBuffer()` method instead of the actual format value. This PR fixes the issue.